### PR TITLE
joplin-deb.sh: optionally allow to define output directory and autoselect available podman instead of docker util

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,32 @@ Tested on Debian 11, your mileage may vary.
 
 Requirements:
 
+Podman installed (for Ubuntu 20.10 and newer)
+
+```
+apt install podman
+```
+
+or
+
 Docker installed
 ```
-apt-get install docker.io
+apt install docker.io
 sudo gpasswd -a $USER docker
 ```
+
 Usage:
 
-./joplin-deb.sh joplin-version
+./joplin-deb.sh -j joplin-version
 
 Example:
 ```
-./joplin-deb.sh 2.5.12
+./joplin-deb.sh -j 2.8.8
 ```
-If the build is successful, it will create a DEB file in the current user's Downloads folder. 
+If the build is successful, it will create a DEB file in the current $HOME/tmpdir folder by default. You can define output directory by -o argument. 
 
 Install it with:
 ```
-sudo apt install ~/Downloads/joplin-desktop_*.deb
+sudo apt install ~/tmpdir/joplin-desktop_*.deb
 ```
 

--- a/joplin-deb.sh
+++ b/joplin-deb.sh
@@ -1,10 +1,51 @@
 #!/usr/bin/env bash
 
 set -e
-if [ $# -eq 0 ]; then
-    printf "Usage: joplin-deb.sh version\nExample: ./joplin-deb.sh 2.5.12\n"
-    exit 1
-fi
+export LC_ALL=C
+
+__info() { __log 'INFO' $1; }
+__debug() { __log 'DEBUG' $1; }
+__warn() { __log 'WARN' $1; }
+__notice() { __log 'NOTICE' $1; }
+__error() { __log 'ERROR' $1; exit 1; }
+__log() {
+     local level=${1?}
+     shift
+     local code= line="[$(date '+%F %T')] $level: $*"
+     if [ -t 2 ]
+     then
+         case "$level" in
+         INFO) code=36 ;;
+         DEBUG) code=30 ;;
+         WARN) code=33 ;;
+         ERROR) code=31 ;;
+         *) code=37 ;;
+         esac
+         echo -e "\e[${code}m${line}\e[0m"
+     else
+         echo "$line"
+     fi >&2
+}
+
+usage()
+{
+cat << EOF
+usage: $0 -j 2.8.8 [-o ~/tmpdir]
+
+OPTIONS:
+   -h     Show this message
+   -j     Joplin version to build
+  [-o     Output directory]
+EOF
+
+exit 1
+}
+
+control_c()
+{
+  __error "Received interrupt, exiting..."
+  exit $?
+}
 
 box_out()
 {
@@ -23,16 +64,50 @@ box_out()
   tput sgr 0
 }
 
-docker pull node:lts-bullseye-slim
-docker build . --build-arg VERSION=$1 -t joplin-deb
-docker run \
+trap control_c INT SIGHUP SIGINT SIGTERM
+
+while getopts "hj:o:" OPTION
+do
+     case $OPTION in
+         h)
+            usage
+            exit 1
+            ;;
+         j)
+            _versionToBuild=$OPTARG
+            ;;
+         o)
+            _outputDirectory=$OPTARG
+            ;;
+         ?)  
+             usage
+             exit 1
+             ;;
+     esac
+done
+
+[ -z "${_versionToBuild}" ] && usage
+[ -z "${_outputDirectory}" ] && _outputDirectory="${HOME}/tmpdir" && __info "Using ${_outputDirectory} as output directory"
+[ ! -d "${_outputDirectory}" ] && mkdir -p "${_outputDirectory}" && __info "Creating ${_outputDirectory} directory"
+
+if [ -f "$(command -v podman)" -a -x "$(command -v podman)" ]; then
+    _containersUtil=$(command -v podman)
+elif [ -f "$(command -v docker)" -a -x "$(command -v docker)" ]; then
+    _containersUtil=$(command -v docker)
+else 
+    __error  "Cannot find either podman or docker util"
+fi
+
+${_containersUtil} pull node:lts-bullseye-slim
+${_containersUtil} build . --build-arg VERSION=${_versionToBuild} -t joplin-deb
+${_containersUtil} run \
     --rm \
     --name joplin-deb \
-    -v ${HOME}/Downloads:/usr/src/app/Downloads \
-    joplin-deb /bin/bash -c "VERSION=$1 export.sh"
+    -v ${_outputDirectory}:/usr/src/app/Downloads \
+    joplin-deb /bin/bash -c "VERSION=${_versionToBuild} export.sh"
 
 box_out "Build complete!" \
-    "Joplin deb package saved to ${HOME}/Downloads/joplin_$1_amd64.deb" \
+    "Joplin deb package saved to ${_outputDirectory}/joplin_${_versionToBuild}_amd64.deb" \
     "Install with:" \
-    "sudo dpkg -i ~/Downloads/joplin_$1_amd64.deb" \
+    "sudo dpkg -i ~/Downloads/joplin_${_versionToBuild}_amd64.deb" \
     "Or with your package manager of choice"


### PR DESCRIPTION
Several simple improvements for joplin-deb.sh script:
- optionally define output directory for deb file;
- automatically select podman instead of docker if available;
- various logging functions.

Please note that option keys are now strictly required.